### PR TITLE
feat(de): Template support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ rust:
 matrix:
   include:
   - env: RUSTFMT
-    rust: 1.24.0  # `stable`: Locking down for consistent behavior
+    rust: 1.25.0  # `stable`: Locking down for consistent behavior
     install:
       - rustup component add rustfmt-preview
     script:
       - cargo fmt -- --write-mode=diff
   - env: RUSTFLAGS="-D warnings"
-    rust: 1.24.0  # `stable`: Locking down for consistent behavior
+    rust: 1.25.0  # `stable`: Locking down for consistent behavior
     install:
     script:
     - cargo check --tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ matrix:
     rust: 1.25.0  # `stable`: Locking down for consistent behavior
     install:
     script:
-    - cargo check --tests
+    - cargo check --tests --all-features
   - env: CLIPPY_VERSION="0.0.179"
     rust: nightly-2018-01-12
     install:
       - travis_wait cargo install clippy --version $CLIPPY_VERSION || echo "clippy already installed"
     script:
-      - cargo clippy --features "cli serde_yaml serde_json" -- -D clippy
+      - cargo clippy --all-features -- -D clippy
 
 install:
 - rustc -Vv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,30 +47,8 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bytecount"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "cargo_metadata"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "cc"
@@ -84,7 +62,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -129,14 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,25 +133,6 @@ dependencies = [
 [[package]]
 name = "fnv"
 version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "glob"
-version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -237,15 +188,6 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,15 +204,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "liquid"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "chrono 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "skeptic 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -340,18 +281,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -377,17 +310,7 @@ name = "quote"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -424,26 +347,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "same-file"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "same-file"
@@ -452,20 +358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "semver"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -480,7 +372,7 @@ name = "serde_derive"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive_internals 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -491,7 +383,7 @@ name = "serde_derive_internals"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -518,21 +410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "skeptic"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytecount 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo_metadata 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "stager"
 version = "0.1.1"
 dependencies = [
@@ -540,7 +417,7 @@ dependencies = [
  "exitcode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "globwalk 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "liquid 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "liquid 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -598,7 +475,7 @@ name = "syn"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -618,15 +495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -755,16 +623,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "walkdir"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "walkdir"
 version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -774,22 +632,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -823,36 +671,28 @@ dependencies = [
 "checksum atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "af80143d6f7608d746df1520709e5d141c96f240b0e62b0aa41bdfb53374d9d4"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
-"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
-"checksum bytecount 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af27422163679dea46a1a7239dffff64d3dcdc3ba5fe9c49c789fbfe0eb949de"
-"checksum cargo_metadata 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f56ec3e469bca7c276f2eea015aa05c5e381356febdbb0683c2580189604537"
 "checksum cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2b4911e4bdcb4100c7680e7e854ff38e23f1b34d4d9e079efae3da2801341ffc"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum chrono 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ba5f60682a4c264e7f8d77b82e7788938a76befdf949d4a98026d19099c9d873"
+"checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum env_logger 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0561146661ae44c579e993456bc76d11ce1e0c7d745e57b2fa7146b6e49fa2ad"
-"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum exitcode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum globset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "464627f948c3190ae3d04b1bc6d7dca2f785bda0ac01278e6db129ad383dbeb6"
 "checksum globwalk 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa8de923c827eee0ceec0154335946457c76c3bc1d78be163780f699fccd51c0"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
-"checksum liquid 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5abe5a13f7a7a05b0a8ce1a450eb99b15b422565712f766d07d47878e0e175e"
+"checksum liquid 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)" = "46aca55ae6cd2cbe9ee76b845c693dede1d69904dc5012c451954c720fc90343"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
@@ -862,29 +702,22 @@ dependencies = [
 "checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
-"checksum proc-macro2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "388d7ea47318c5ccdeb9ba6312cee7d3f65dd2804be8580a170fce410d50b786"
-"checksum pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fdf85cda6cadfae5428a54661d431330b312bc767ddbc57adbedc24da66e32"
+"checksum proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "49b6a521dc81b643e9a51e0d1cf05df46d5a2f3c0280ea72bcb68276ba64a118"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
 "checksum quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0ff51282f28dc1b53fd154298feaa2e77c5ea0dba68e1fd8b03b72fbe13d2a"
-"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
 "checksum regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2550876c31dc914696a6c2e01cbce8afba79a93c8ae979d2fe051c0230b3756"
-"checksum remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfc5b3ce5d5ea144bb04ebd093a9e14e9765bcfec866aecda9b6dec43b3d1e24"
 "checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
-"checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
-"checksum semver 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bee2bc909ab2d8d60dab26e8cad85b25d795b14603a0dcb627b78b9d30b6454b"
-"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "d3bcee660dcde8f52c3765dd9ca5ee36b4bf35470a738eb0bd5a8752b0389645"
 "checksum serde_derive 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "f1711ab8b208541fa8de00425f6a577d90f27bb60724d2bb5fd911314af9668f"
 "checksum serde_derive_internals 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89b340a48245bc03ddba31d0ff1709c118df90edc6adabaca4aac77aea181cce"
 "checksum serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "5c508584d9913df116b91505eec55610a2f5b16e9ed793c46e4d0152872b3e74"
 "checksum serde_yaml 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e0f868d400d9d13d00988da49f7f02aeac6ef00f11901a8c535bd59d777b9e19"
-"checksum skeptic 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c8431f8fca168e2db4be547bd8329eac70d095dff1444fee4b0fa0fabc7df75a"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3e7486f53a0c0c2bcc35acb8a792185c069eefd19a98450dd0578f35af396aab"
 "checksum structopt-derive 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9ab6d6241f3255ce453eee9a84d4c250ed0f04e18d08131d6f23282c1d3355ad"
@@ -893,7 +726,6 @@ dependencies = [
 "checksum syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91b52877572087400e83d24b9178488541e3d535259e04ff17a63df1e5ceff59"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
-"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
@@ -912,11 +744,8 @@ dependencies = [
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"
 "checksum walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "63636bd0eb3d00ccb8b9036381b526efac53caf112b7783b730ab3f8e44da369"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,14 @@ keywords = ["cli", "packaging"]
 
 [[bin]]
 name = "staging"
-required-features = ["cli"]
+required-features = ["cli", "de"]
 
 [features]
-default = []
+default = ["de"]
+de = [
+    "serde",
+    "liquid",
+]
 cli = [
     "env_logger",
     "exitcode",
@@ -26,9 +30,10 @@ cli = [
 [dependencies]
 failure = "0.1.1"
 globwalk = "0.1"
-liquid = "0.14.1"
 log = "0.4"
-serde = { version = "1.0", features = ["derive"] }
+
+liquid = { version = "0.14", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 env_logger = { version = "0.5", optional = true }
 exitcode = { version = "1.1", optional = true }

--- a/src/bin/staging/main.rs
+++ b/src/bin/staging/main.rs
@@ -2,6 +2,8 @@
 
 extern crate env_logger;
 extern crate exitcode;
+extern crate globwalk;
+extern crate liquid;
 extern crate stager;
 
 #[macro_use]
@@ -22,56 +24,62 @@ use std::ffi;
 use std::fs;
 use std::io::Write;
 use std::io;
-use std::io::Read;
 use std::path;
 use std::process;
 
 use failure::ResultExt;
 use structopt::StructOpt;
 
-#[cfg(feature = "serde_yaml")]
-fn load_yaml(path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
-    let f = fs::File::open(path)?;
-    serde_yaml::from_reader(f).map_err(|e| e.into())
-}
+use stager::de::Render;
 
-#[cfg(not(feature = "serde_yaml"))]
-fn load_yaml(_path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
-    bail!("yaml is unsupported");
-}
+mod stage {
+    use super::*;
+    use std::io::Read;
 
-#[cfg(feature = "serde_json")]
-fn load_json(path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
-    let f = fs::File::open(path)?;
-    serde_json::from_reader(f).map_err(|e| e.into())
-}
+    #[cfg(feature = "serde_yaml")]
+    pub fn load_yaml(path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
+        let f = fs::File::open(path)?;
+        serde_yaml::from_reader(f).map_err(|e| e.into())
+    }
 
-#[cfg(not(feature = "serde_json"))]
-fn load_json(_path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
-    bail!("json is unsupported");
-}
+    #[cfg(not(feature = "serde_yaml"))]
+    pub fn load_yaml(_path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
+        bail!("yaml is unsupported");
+    }
 
-#[cfg(feature = "toml")]
-fn load_toml(path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
-    let mut f = fs::File::open(path)?;
-    let mut text = String::new();
-    f.read_to_string(&mut text)?;
-    toml::from_str(&text).map_err(|e| e.into())
-}
+    #[cfg(feature = "serde_json")]
+    pub fn load_json(path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
+        let f = fs::File::open(path)?;
+        serde_json::from_reader(f).map_err(|e| e.into())
+    }
 
-#[cfg(not(feature = "toml"))]
-fn load_toml(_path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
-    bail!("toml is unsupported");
+    #[cfg(not(feature = "serde_json"))]
+    pub fn load_json(_path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
+        bail!("json is unsupported");
+    }
+
+    #[cfg(feature = "toml")]
+    pub fn load_toml(path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
+        let mut f = fs::File::open(path)?;
+        let mut text = String::new();
+        f.read_to_string(&mut text)?;
+        toml::from_str(&text).map_err(|e| e.into())
+    }
+
+    #[cfg(not(feature = "toml"))]
+    pub fn load_toml(_path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
+        bail!("toml is unsupported");
+    }
 }
 
 fn load_stage(path: &path::Path) -> Result<stager::de::Staging, failure::Error> {
     let extension = path.extension().unwrap_or_default();
     let value = if extension == ffi::OsStr::new("yaml") {
-        load_yaml(path)
+        stage::load_yaml(path)
     } else if extension == ffi::OsStr::new("toml") {
-        load_toml(path)
+        stage::load_toml(path)
     } else if extension == ffi::OsStr::new("json") {
-        load_json(path)
+        stage::load_json(path)
     } else {
         bail!("Unsupported file type");
     }?;
@@ -79,13 +87,155 @@ fn load_stage(path: &path::Path) -> Result<stager::de::Staging, failure::Error> 
     Ok(value)
 }
 
+mod object {
+    use super::*;
+    use std::io::Read;
+
+    #[cfg(feature = "serde_yaml")]
+    pub fn load_yaml(path: &path::Path) -> Result<liquid::Value, failure::Error> {
+        let f = fs::File::open(path)?;
+        serde_yaml::from_reader(f).map_err(|e| e.into())
+    }
+
+    #[cfg(not(feature = "serde_yaml"))]
+    pub fn load_yaml(_path: &path::Path) -> Result<liquid::Value, failure::Error> {
+        bail!("yaml is unsupported");
+    }
+
+    #[cfg(feature = "serde_json")]
+    pub fn load_json(path: &path::Path) -> Result<liquid::Value, failure::Error> {
+        let f = fs::File::open(path)?;
+        serde_json::from_reader(f).map_err(|e| e.into())
+    }
+
+    #[cfg(not(feature = "serde_json"))]
+    pub fn load_json(_path: &path::Path) -> Result<liquid::Value, failure::Error> {
+        bail!("json is unsupported");
+    }
+
+    #[cfg(feature = "toml")]
+    pub fn load_toml(path: &path::Path) -> Result<liquid::Value, failure::Error> {
+        let mut f = fs::File::open(path)?;
+        let mut text = String::new();
+        f.read_to_string(&mut text)?;
+        toml::from_str(&text).map_err(|e| e.into())
+    }
+
+    #[cfg(not(feature = "toml"))]
+    pub fn load_toml(_path: &path::Path) -> Result<liquid::Value, failure::Error> {
+        bail!("toml is unsupported");
+    }
+
+    pub fn insert(
+        object: &mut liquid::Object,
+        path: Vec<String>,
+        key: String,
+        value: liquid::Value,
+    ) -> Result<(), failure::Error> {
+        let leaf = path.iter().cloned().fold(Ok(object), |object, key| {
+            let cur_object = object?;
+            let object = cur_object
+                .entry(key)
+                .or_insert_with(|| liquid::Value::Object(liquid::Object::new()))
+                .as_object_mut()
+                .ok_or_else(|| {
+                    failure::Context::new(format!(
+                        "Aborting: Duplicate in data tree. Would overwrite {:?} ",
+                        path
+                    ))
+                });
+            object
+        })?;
+
+        match leaf.insert(key, value) {
+            None => Ok(()),
+            _ => bail!(
+                "The data from {:?} can't be loaded: the key already exists",
+                path
+            ),
+        }
+    }
+}
+
+fn load_data(path: &path::Path) -> Result<liquid::Value, failure::Error> {
+    let extension = path.extension().unwrap_or_default();
+    let value = if extension == ffi::OsStr::new("yaml") {
+        object::load_yaml(path)
+    } else if extension == ffi::OsStr::new("toml") {
+        object::load_toml(path)
+    } else if extension == ffi::OsStr::new("json") {
+        object::load_json(path)
+    } else {
+        bail!("Unsupported file type");
+    }?;
+
+    Ok(value)
+}
+
+fn load_data_dirs(roots: &[path::PathBuf]) -> Result<liquid::Object, failure::Error> {
+    let mut object = liquid::Object::new();
+    // TODO(epage): swap out globwalk for something that uses gitignore so we can have
+    // exclusion support.
+    let patterns = [
+        #[cfg(feature = "serde_yaml")]
+        "*.yaml",
+        #[cfg(feature = "serde_json")]
+        "*.json",
+        #[cfg(feature = "toml")]
+        "*.toml",
+    ];
+    for root in roots {
+        for entry in globwalk::GlobWalker::from_patterns(&patterns, root)? {
+            let entry = entry?;
+            let data_file = entry.path();
+            let data = load_data(data_file)?;
+            let rel_source = data_file.strip_prefix(&root)?;
+            let path = rel_source.parent().unwrap_or(path::Path::new(""));
+            let path: Option<Vec<_>> = path.components()
+                .map(|c| {
+                    let c: &ffi::OsStr = c.as_ref();
+                    c.to_str().map(String::from)
+                })
+                .collect();
+            let path = match path {
+                Some(p) => p,
+                None => {
+                    warn!("Invalid data file path: {:?}", rel_source);
+                    continue;
+                }
+            };
+            let key = match rel_source
+                .file_name()
+                .expect("file name to exist due to globwalk")
+                .to_str()
+                .map(String::from)
+            {
+                Some(p) => p,
+                None => {
+                    warn!("Invalid data file path: {:?}", rel_source);
+                    continue;
+                }
+            };
+            object::insert(&mut object, path, key, data)?;
+        }
+    }
+
+    Ok(object)
+}
+
 #[derive(StructOpt, Debug)]
 #[structopt(name = "staging")]
 struct Arguments {
-    #[structopt(short = "i", long = "input", name = "STAGE")] input: String,
-    #[structopt(short = "o", long = "output", name = "DIR")] output: String,
-    #[structopt(short = "n", long = "dry-run")] dry_run: bool,
-    #[structopt(short = "v", long = "verbose", parse(from_occurrences))] verbosity: u8,
+    #[structopt(short = "i", long = "input", name = "STAGE", parse(from_os_str))]
+    input_stage: path::PathBuf,
+    #[structopt(short = "d", long = "data", name = "DATA_DIR", parse(from_os_str))]
+    data_dir: Vec<path::PathBuf>,
+    #[structopt(short = "o", long = "output", name = "OUT_DIR", parse(from_os_str))]
+    output_dir: path::PathBuf,
+    #[structopt(short = "n", long = "dry-run")]
+    dry_run: bool,
+    #[structopt(short = "v", long = "verbose", parse(from_occurrences))]
+    verbosity: u8,
 }
 
 fn run() -> Result<exitcode::ExitCode, failure::Error> {
@@ -113,18 +263,13 @@ fn run() -> Result<exitcode::ExitCode, failure::Error> {
     }
     builder.init();
 
-    let staging = load_stage(path::Path::new(&args.input))
-        .with_context(|_| format!("Failed to load {:?}", args.input))?;
-    let output_root = path::PathBuf::from(args.output);
+    let data = load_data_dirs(&args.data_dir)?;
+    let engine = stager::de::TemplateEngine::new(data)?;
 
-    let staging: Result<Vec<_>, _> = staging
-        .into_iter()
-        .map(|(target, sources)| {
-            let sources: Vec<stager::de::Source> = sources;
-            let sources: Result<Vec<_>, _> = sources.into_iter().map(|s| s.format()).collect();
-            sources.map(|s| (target, s))
-        })
-        .collect();
+    let staging = load_stage(&args.input_stage)
+        .with_context(|_| format!("Failed to load {:?}", args.input_stage))?;
+
+    let staging = staging.format(&engine);
     // TODO(epage): Show all errors, not just first
     let staging = match staging {
         Ok(s) => s,
@@ -137,7 +282,7 @@ fn run() -> Result<exitcode::ExitCode, failure::Error> {
     let staging: Result<Vec<_>, _> = staging
         .into_iter()
         .map(|(target, sources)| {
-            let target = output_root.join(target);
+            let target = args.output_dir.join(target);
             let sources: Vec<Box<stager::builder::ActionBuilder>> = sources;
             let sources: Result<Vec<_>, _> =
                 sources.into_iter().map(|s| s.build(&target)).collect();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -40,7 +40,7 @@ impl ActionBuilder for Directory {
 #[derive(Clone, Debug)]
 pub struct SourceFile {
     ///  Specifies the full path of the file to be copied into the target directory
-    pub path: String,
+    pub path: path::PathBuf,
     /// Specifies the name the target file should be renamed as when copying from the source file.
     /// Default is the filename of the source file.
     pub rename: Option<String>,
@@ -52,7 +52,7 @@ pub struct SourceFile {
 
 impl ActionBuilder for SourceFile {
     fn build(&self, target_dir: &path::Path) -> Result<Vec<Box<action::Action>>, failure::Error> {
-        let path = path::Path::new(&self.path);
+        let path = self.path.as_path();
         let filename = self.rename
             .as_ref()
             .map(|n| ffi::OsStr::new(n))
@@ -82,7 +82,7 @@ impl ActionBuilder for SourceFile {
 pub struct SourceFiles {
     ///  Specifies the root path that `patterns` will be run on to identify files to be copied into
     ///  the target directory.
-    pub path: String,
+    pub path: path::PathBuf,
     /// Specifies the pattern for executing the recursive/multifile match.
     pub pattern: Vec<String>,
     pub follow_links: bool,
@@ -94,7 +94,7 @@ impl ActionBuilder for SourceFiles {
         let mut actions: Vec<Box<action::Action>> = Vec::new();
         // TODO(epage): swap out globwalk for something that uses gitignore so we can have
         // exclusion support.
-        let source_root = path::Path::new(&self.path);
+        let source_root = self.path.as_path();
         for entry in globwalk::GlobWalker::from_patterns(&self.pattern, source_root)?
             .follow_links(self.follow_links)
         {
@@ -129,7 +129,7 @@ impl ActionBuilder for SourceFiles {
 #[derive(Clone, Debug)]
 pub struct Symlink {
     /// The literal path for the target to point to.
-    pub target: String,
+    pub target: path::PathBuf,
     /// Specifies the name the symlink should be given.
     /// Default is the filename of the `target`.
     pub rename: String,
@@ -138,7 +138,7 @@ pub struct Symlink {
 
 impl ActionBuilder for Symlink {
     fn build(&self, target_dir: &path::Path) -> Result<Vec<Box<action::Action>>, failure::Error> {
-        let target = path::Path::new(&self.target);
+        let target = self.target.as_path();
         let staged = target_dir.join(&self.rename);
         let link: Box<action::Action> = Box::new(action::Symlink::new(&staged, target));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,13 @@
 #[macro_use]
 extern crate failure;
 extern crate globwalk;
+#[cfg(feature = "de")]
+extern crate liquid;
+#[cfg(feature = "de")]
 #[macro_use]
 extern crate serde;
 
 pub mod action;
 pub mod builder;
+#[cfg(feature = "de")]
 pub mod de;


### PR DESCRIPTION
Most fields in the deserialization format now support Liquid
expressions.

As part of this, `de` has been made into a default feature so users can
turn it off if desired.

Fixes #1 String Template Support
Fixex #8 Data Directory Support

BREAKING CHANGES:
- Paths with `{` or `}` might end up being treated as liquid templates.
  Later this can be worked around when the `raw` tag is supported.
- API changes to make the above possible.