### PR TITLE
feat(de): Define path handling rules

### DIFF
--- a/src/bin/staging/main.rs
+++ b/src/bin/staging/main.rs
@@ -278,9 +278,14 @@ fn run() -> Result<exitcode::ExitCode, failure::Error> {
         }
     };
 
+    // TODO(epage): Move this logic to `stager::builder` for reuse.
     let staging: Result<Vec<_>, _> = staging
         .into_iter()
         .map(|(target, sources)| {
+            if target.is_absolute() {
+                // This should already be enforced by `stager::de`.
+                bail!("target must be relative to the stage root: {:?}", target);
+            }
             let target = args.output_dir.join(target);
             let sources: Vec<Box<stager::builder::ActionBuilder>> = sources;
             let sources: Result<Vec<_>, _> =


### PR DESCRIPTION
config format (de)
- target must be absolute, treating the target staging folder as the root

builder
- target must be relativve
- SourceFile::path must be absolute
- SourceFile::reame can only be a filename
- SourceFiles::path must be absolute
- Symlink::renamre can only be a filename

BREAKING CHANGE: Stricter path requirements.