### PR TITLE
feat(de): ignore 'nothing found' error option

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -102,6 +102,12 @@ pub struct SourceFiles {
     /// Specifies the pattern for executing the recursive/multifile match.
     pub pattern: Vec<String>,
     pub follow_links: bool,
+    /// Toggles whether no results for the pattern constitutes an error.
+    ///
+    /// Generally, the default of `false` is best because it makes mistakes more obvious.  An
+    /// example of when no results are acceptable is a default staging configuration that
+    /// implements a lot of default "good enough" policy.
+    pub allow_empty: bool,
     pub access: Vec<Access>,
 }
 
@@ -133,11 +139,18 @@ impl ActionBuilder for SourceFiles {
         }
 
         if actions.is_empty() {
-            bail!(
-                "No files found under {:?} with patterns {:?}",
-                self.path,
-                self.pattern
-            );
+            if self.allow_empty {
+                info!(
+                    "No files found under {:?} with patterns {:?}",
+                    self.path, self.pattern
+                );
+            } else {
+                bail!(
+                    "No files found under {:?} with patterns {:?}",
+                    self.path,
+                    self.pattern
+                );
+            }
         }
 
         Ok(actions)

--- a/src/de.rs
+++ b/src/de.rs
@@ -137,6 +137,13 @@ pub struct SourceFiles {
     pattern: OneOrMany<Template>,
     #[serde(default)]
     follow_links: bool,
+    /// Toggles whether no results for the pattern constitutes an error.
+    ///
+    /// Generally, the default of `false` is best because it makes mistakes more obvious.  An
+    /// example of when no results are acceptable is a default staging configuration that
+    /// implements a lot of default "good enough" policy.
+    #[serde(default)]
+    allow_empty: bool,
     #[serde(default)]
     access: Option<OneOrMany<Access>>,
 }
@@ -155,6 +162,7 @@ impl Render for SourceFiles {
             path: path::PathBuf::from(self.path.format(engine)?),
             pattern,
             follow_links: self.follow_links,
+            allow_empty: self.allow_empty,
             access,
         };
         Ok(value)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ extern crate failure;
 extern crate globwalk;
 #[cfg(feature = "de")]
 extern crate liquid;
+#[macro_use]
+extern crate log;
 #[cfg(feature = "de")]
 #[macro_use]
 extern crate serde;


### PR DESCRIPTION
`allow_empty` is an escape hatch to enable a default policy in a staging
tool (like a future cargo-tarball) that includes features if the user
has them (e.g. completions, docs, etc).