### PR TITLE
 fix: Report all errors

### DIFF
--- a/src/bin/staging/main.rs
+++ b/src/bin/staging/main.rs
@@ -270,7 +270,6 @@ fn run() -> Result<exitcode::ExitCode, failure::Error> {
         .with_context(|_| format!("Failed to load {:?}", args.input_stage))?;
 
     let staging = staging.format(&engine);
-    // TODO(epage): Show all errors, not just first
     let staging = match staging {
         Ok(s) => s,
         Err(e) => {
@@ -280,7 +279,6 @@ fn run() -> Result<exitcode::ExitCode, failure::Error> {
     };
 
     let staging = staging.build(&args.output_dir);
-    // TODO(epage): Show all errors, not just first
     let staging = match staging {
         Ok(s) => s,
         Err(e) => {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::ffi;
+use std::iter;
 use std::path;
 
 use failure;
@@ -9,12 +10,49 @@ use globwalk;
 
 use action;
 
-pub type Staging = BTreeMap<path::PathBuf, Vec<Box<ActionBuilder>>>;
-
 pub trait ActionBuilder {
     // TODO(epage):
     // - Change to `Iterator`.
     fn build(&self, target_dir: &path::Path) -> Result<Vec<Box<action::Action>>, failure::Error>;
+}
+
+/// For each stage target, a list of sources to populate it with.
+///
+/// The target is a path relative to the stage root.
+pub struct Staging(BTreeMap<path::PathBuf, Vec<Box<ActionBuilder>>>);
+
+impl ActionBuilder for Staging {
+    fn build(&self, target_dir: &path::Path) -> Result<Vec<Box<action::Action>>, failure::Error> {
+        let staging: Result<Vec<_>, _> = self.0
+            .iter()
+            .map(|(target, sources)| {
+                if target.is_absolute() {
+                    bail!("target must be relative to the stage root: {:?}", target);
+                }
+                let target = target_dir.join(target);
+                let sources: &Vec<Box<ActionBuilder>> = sources;
+                let sources: Result<Vec<_>, _> =
+                    sources.into_iter().map(|s| s.build(&target)).collect();
+                sources
+            })
+            .collect();
+        let staging = staging?;
+        let staging: Vec<_> = staging
+            .into_iter()
+            .flat_map(|v| v.into_iter().flat_map(|v: Vec<_>| v.into_iter()))
+            .collect();
+        Ok(staging)
+    }
+}
+
+impl iter::FromIterator<(path::PathBuf, Vec<Box<ActionBuilder>>)> for Staging {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = (path::PathBuf, Vec<Box<ActionBuilder>>)>,
+    {
+        let staging = iter.into_iter().collect();
+        Self { 0: staging }
+    }
 }
 
 /// Override the default settings for the target directory.

--- a/src/de.rs
+++ b/src/de.rs
@@ -7,6 +7,7 @@ use failure;
 use liquid;
 
 use builder;
+use error;
 
 /// Translate user-facing configuration to the staging APIs.
 pub trait Render {
@@ -26,17 +27,26 @@ impl Render for Staging {
     type Rendered = builder::Staging;
 
     fn format(&self, engine: &TemplateEngine) -> Result<builder::Staging, failure::Error> {
-        let staging: Result<builder::Staging, _> = self.0
-            .iter()
-            .map(|(target, sources)| {
-                let target = abs_to_rel(&target.format(engine)?)?;
-                let sources: &Vec<Source> = sources;
-                let sources: Result<Vec<_>, _> =
-                    sources.into_iter().map(|s| s.format(engine)).collect();
-                sources.map(|s| (target, s))
-            })
-            .collect();
-        staging
+        let iter = self.0.iter().map(|(target, sources)| {
+            let target = abs_to_rel(&target.format(engine)?)?;
+            let sources: &Vec<Source> = sources;
+            let mut errors = error::Errors::new();
+            let sources = {
+                let sources = sources.into_iter().map(|s| s.format(engine));
+                let sources = error::ErrorPartition::new(sources, &mut errors);
+                let sources: Vec<_> = sources.collect();
+                sources
+            };
+            errors.ok((target, sources))
+        });
+        let mut errors = error::Errors::new();
+        let staging = {
+            let iter = error::ErrorPartition::new(iter, &mut errors);
+            let staging: builder::Staging = iter.collect();
+            staging
+        };
+
+        errors.ok(staging)
     }
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -26,7 +26,7 @@ impl Render for Staging {
     type Rendered = builder::Staging;
 
     fn format(&self, engine: &TemplateEngine) -> Result<builder::Staging, failure::Error> {
-        let staging: Result<BTreeMap<_, _>, _> = self.0
+        let staging: Result<builder::Staging, _> = self.0
             .iter()
             .map(|(target, sources)| {
                 let target = abs_to_rel(&target.format(engine)?)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,108 @@
+use std::fmt;
+use std::iter;
+
+use failure;
+
+pub struct ErrorPartition<'e, I> {
+    iter: I,
+    errors: &'e mut Errors,
+}
+
+impl<'e, I, T> ErrorPartition<'e, I>
+where
+    I: Iterator<Item = Result<T, failure::Error>>,
+{
+    pub fn new(iter: I, errors: &'e mut Errors) -> Self {
+        Self { iter, errors }
+    }
+}
+
+impl<'e, I> fmt::Debug for ErrorPartition<'e, I>
+where
+    I: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ErrorPartition")
+            .field("iter", &self.iter)
+            .field("errors", &self.errors)
+            .finish()
+    }
+}
+
+impl<'e, I, T> Iterator for ErrorPartition<'e, I>
+where
+    I: Iterator<Item = Result<T, failure::Error>>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        for item in &mut self.iter {
+            match item {
+                Ok(item) => return Some(item),
+                Err(item) => self.errors.push(item),
+            }
+        }
+
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+#[derive(Debug)]
+pub struct Errors {
+    errors: Vec<failure::Error>,
+}
+
+impl Errors {
+    pub fn new() -> Self {
+        Self { errors: Vec::new() }
+    }
+
+    pub fn push(&mut self, error: failure::Error) {
+        self.errors.push(error);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    pub fn ok<T>(self, value: T) -> Result<T, failure::Error> {
+        if self.is_empty() {
+            Ok(value)
+        } else {
+            Err(self.into())
+        }
+    }
+}
+
+impl failure::Fail for Errors {
+    fn cause(&self) -> Option<&failure::Fail> {
+        None
+    }
+
+    fn backtrace(&self) -> Option<&failure::Backtrace> {
+        None
+    }
+}
+
+impl fmt::Display for Errors {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for error in &self.errors {
+            writeln!(f, "{}", error)?;
+        }
+        Ok(())
+    }
+}
+
+impl iter::FromIterator<failure::Error> for Errors {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = failure::Error>,
+    {
+        let errors = iter.into_iter().collect();
+        Self { errors }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,5 @@ pub mod action;
 pub mod builder;
 #[cfg(feature = "de")]
 pub mod de;
+
+mod error;


### PR DESCRIPTION
At each phase of processing, all errors are returned.  For `stage`, the
application bails out at the end of that processing phase.

My hope was to keep the `ErrorPredicate` and `Errors` decoupled.  My
hope had been it would build up the errors internally and that a user
could then access it after.  The problem is that `collect` takes
ownership of the iterator.

Fixes #3

BREAKING CHANGE: `builder::Staging` changed from a type def to a
distinct type.